### PR TITLE
Add link preview to promo website

### DIFF
--- a/src/components/seo.tsx
+++ b/src/components/seo.tsx
@@ -49,12 +49,20 @@ function SEO({ description, lang, meta, title }) {
           content: metaDescription,
         },
         {
+          property: `og:image`,
+          content: '../../assets/VH Pixel Logo.png',
+        },
+        {
           property: `og:type`,
           content: `website`,
         },
         {
           name: `twitter:card`,
-          content: `summary`,
+          content: `summary_large_image`,
+        },
+        {
+          name: `twitter:site`,
+          content: site.siteMetadata.author,
         },
         {
           name: `twitter:creator`,

--- a/src/components/seo.tsx
+++ b/src/components/seo.tsx
@@ -7,7 +7,7 @@
 
 import React from "react"
 import PropTypes from "prop-types"
-import RetroLogo from '../../assets/VH Pixel Logo.png';
+import RetroLogo from '../assets/VH Pixel Logo.png';
 import  { Helmet } from "react-helmet"
 import { useStaticQuery, graphql } from "gatsby"
 

--- a/src/components/seo.tsx
+++ b/src/components/seo.tsx
@@ -63,15 +63,15 @@ function SEO({ description, lang, meta, title }) {
         },
         {
           name: `twitter:site`,
-          content: site.siteMetadata.author,
+          content: `@vandyhacks`,
         },
         {
           name: `twitter:creator`,
-          content: site.siteMetadata.author,
+          content: `@vandyhacks`,
         },
         {
           name: `twitter:title`,
-          content: title,
+          content: `VandyHacks: Retro Edition`,
         },
         {
           name: `twitter:description`,

--- a/src/components/seo.tsx
+++ b/src/components/seo.tsx
@@ -7,6 +7,7 @@
 
 import React from "react"
 import PropTypes from "prop-types"
+import RetroLogo from '../../assets/VH Pixel Logo.png';
 import  { Helmet } from "react-helmet"
 import { useStaticQuery, graphql } from "gatsby"
 
@@ -50,7 +51,7 @@ function SEO({ description, lang, meta, title }) {
         },
         {
           property: `og:image`,
-          content: '../../assets/VH Pixel Logo.png',
+          content: RetroLogo,
         },
         {
           property: `og:type`,


### PR DESCRIPTION
changed title to "VandyHacks: Retro Edition" instead of "Home", the twitter usernames should have an @ to follow spec which has also been done.

Uses RetroLogo for preview which works amazingly for Discord, but not as well for telegram since transparent bg. 

![image](https://user-images.githubusercontent.com/27063113/91689917-ac775900-eb82-11ea-9908-4fe7519ddddd.png)
